### PR TITLE
feat(legend,timeline): human-readable legend, color palette, 24h time…

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -303,6 +303,33 @@ body {
   text-align: center;
 }
 
+.legend-vertical { display: flex; flex-direction: row; gap: 10px; align-items: stretch; }
+.legend-gradient-bar { width: 160px; height: 8px; border-radius: 4px; border: 1px solid rgba(255,255,255,0.2);
+  background: linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,168,0,1) 15%, rgba(255,215,0,1) 40%, rgba(255,140,0,1) 60%, rgba(255,69,0,1) 80%, rgba(255,0,255,1) 100%);
+}
+.legend-gradient-bar.vertical { width: 8px; height: 200px; background: linear-gradient(180deg,
+  rgba(255,0,255,1) 0%,          /* magenta */
+  rgba(255,69,0,1) 18%,          /* red-orange */
+  rgba(255,140,0,1) 36%,         /* orange */
+  rgba(255,215,0,1) 55%,         /* yellow */
+  rgba(0,168,0,1) 75%,           /* green */
+  rgba(56,189,248,1) 88%,        /* light blue */
+  rgba(37,99,235,1) 100%         /* blue */
+); }
+.legend-ticklist { display: flex; flex-direction: column; gap: 4px; justify-content: space-between; }
+.legend-tick { display: flex; justify-content: space-between; gap: 12px; font-size: 11px; color: #e2e8f0; }
+.legend-tick .tick-label { color: #e2e8f0; }
+.legend-tick .tick-value { color: #94a3b8; margin-left: auto; text-align: right; min-width: 64px; }
+
+.ptype-row { display: flex; align-items: center; justify-content: space-between; margin-top: 10px; }
+.ptype-label { font-size: 11px; color: #e2e8f0; }
+.ptype-badge { font-size: 11px; padding: 2px 6px; border-radius: 12px; border: 1px solid rgba(255,255,255,0.2); }
+.ptype-rain { background: rgba(59,130,246,0.2); color: #93c5fd; border-color: rgba(147,197,253,0.5); }
+.ptype-snow { background: rgba(226,232,240,0.2); color: #e2e8f0; border-color: rgba(226,232,240,0.5); }
+.ptype-freezing { background: rgba(217,70,239,0.2); color: #f0abfc; border-color: rgba(240,171,252,0.5); }
+.ptype-mix { background: rgba(234,179,8,0.2); color: #fde68a; border-color: rgba(253,230,138,0.5); }
+.ptype-none { background: rgba(30,41,59,0.2); color: #94a3b8; }
+
 .legend-scale {
   display: flex;
   flex-direction: column;
@@ -317,6 +344,19 @@ body {
   font-size: 12px;
   color: #e2e8f0;
 }
+
+.legend-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.12);
+  margin: 8px 0 10px;
+}
+
+.overlay-scale .legend-item {
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+/* overlay controls removed per requirements */
 
 .legend-color-info {
   display: flex;
@@ -340,25 +380,54 @@ body {
   text-align: right;
 }
 
-/* Updated legend colors to match radar intensity */
+/* Updated legend colors to match RainViewer radar reflectivity */
 .legend-clear {
   background: transparent;
   border-color: rgba(255, 255, 255, 0.3);
 }
-.legend-light {
-  background: rgba(136, 255, 136, 0.7);
+.legend-light { background: rgba(0, 168, 0, 0.75); }      /* green */
+.legend-moderate { background: rgba(255, 215, 0, 0.85); }  /* yellow */
+.legend-heavy { background: rgba(255, 140, 0, 0.9); }      /* orange */
+.legend-intense { background: rgba(255, 69, 0, 0.95); }    /* red-orange */
+.legend-extreme { background: rgba(255, 0, 255, 1); }      /* magenta */
+
+/* Overlay type swatches */
+.overlay-clouds { background: rgba(180, 186, 200, 0.9); }
+
+/* Apple-like visual tuning (non-destructive, purely cosmetic) */
+.leaflet-tile.basemap-layer {
+  filter: saturate(1.05) contrast(1.0) brightness(1.02) hue-rotate(0deg);
 }
-.legend-moderate {
-  background: rgba(255, 255, 0, 0.8);
+
+.leaflet-tile.rainviewer-radar-layer {
+  /* Brighter look on light basemap */
+  filter: saturate(1.05) contrast(1.05);
+  mix-blend-mode: multiply;
+  opacity: 0.84;
 }
-.legend-heavy {
-  background: rgba(255, 165, 0, 0.9);
+
+.leaflet-tile.owm-clouds-layer {
+  filter: opacity(0.75) saturate(0.9) contrast(1.02);
 }
-.legend-intense {
-  background: rgba(255, 69, 0, 0.95);
+
+.leaflet-tile.owm-precip-layer-light {
+  mix-blend-mode: multiply;
 }
-.legend-extreme {
-  background: rgba(255, 0, 0, 1);
+
+.leaflet-tile.owm-precip-layer-intensity {
+  mix-blend-mode: color-burn;
+}
+
+.leaflet-tile.owm-snow-layer {
+  mix-blend-mode: screen;
+}
+
+/* Slight softening using backdrop blur behind legend for cohesion */
+.radar-legend {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  background: rgba(10, 15, 20, 0.74);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 /* Timeline Controls - More transparent and minimalist */
@@ -401,43 +470,15 @@ body {
   letter-spacing: 0.5px;
 }
 
-.timeline-controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px; /* Reduced gap */
-  margin-bottom: 8px; /* Reduced margin */
-}
+.timeline-controls { display: none; }
 
-.timeline-btn {
-  background: rgba(26, 35, 50, 0.4); /* More transparent */
-  border: 1px solid rgba(255, 255, 255, 0.08); /* More transparent border */
-  border-radius: 4px; /* More minimalist border radius */
-  padding: 6px 10px; /* Reduced padding */
-  color: #e2e8f0;
-  font-size: 11px; /* Smaller font */
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  gap: 3px; /* Reduced gap */
-}
+.timeline-btn { display: none; }
 
-.timeline-btn:hover {
-  background: rgba(26, 35, 50, 0.6);
-  border-color: rgba(255, 255, 255, 0.15);
-  color: #ffffff;
-}
+.timeline-btn:hover { display: none; }
 
-.timeline-btn:active {
-  transform: scale(0.95);
-}
+.timeline-btn:active { display: none; }
 
-.timeline-btn.active {
-  background: rgba(16, 185, 129, 0.8); /* Slightly transparent active state */
-  border-color: rgba(16, 185, 129, 0.6);
-  color: #ffffff;
-}
+.timeline-btn.active { display: none; }
 
 .timeline-slider {
   width: 100%;

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -5,11 +5,12 @@ let timelineAnimationId = null;
 
 // Time formatting functions
 function formatTime(date) {
-  return date.toLocaleTimeString("en-US", {
-    hour: "numeric",
+  // 24-hour format HH:MM:SS
+  return date.toLocaleTimeString("en-CA", {
+    hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
-    hour12: true,
+    hour12: false,
   });
 }
 
@@ -37,15 +38,7 @@ function updateCurrentTime() {
   }
 
   if (statusElement) {
-    if (isLiveMode) {
-      statusElement.textContent = "Live • Current Local Time";
-    } else if (currentTimeOffset < 0) {
-      statusElement.textContent = `${Math.abs(currentTimeOffset)} min ago`;
-    } else if (currentTimeOffset > 0) {
-      statusElement.textContent = `${currentTimeOffset} min forecast`;
-    } else {
-      statusElement.textContent = "Current Time";
-    }
+    statusElement.textContent = "Current Time";
   }
 }
 
@@ -60,55 +53,11 @@ function updateTimelineHandle() {
 }
 
 // Timeline control functions
-function replayRadar() {
-  console.log("Replay radar clicked");
-  isLiveMode = false;
-  currentTimeOffset = -30;
+function replayRadar() {}
 
-  // Update UI
-  updateTimelineButtons();
-  updateCurrentTime();
-  updateTimelineHandle();
+function goLive() {}
 
-  // Start animation from -30 to current time
-  animateReplay();
-}
-
-function goLive() {
-  console.log("Go live clicked");
-  isLiveMode = true;
-  currentTimeOffset = 0;
-
-  // Stop any animation
-  if (timelineAnimationId) {
-    cancelAnimationFrame(timelineAnimationId);
-    timelineAnimationId = null;
-  }
-
-  // Update UI
-  updateTimelineButtons();
-  updateCurrentTime();
-  updateTimelineHandle();
-
-  // Refresh radar data
-  if (window.loadRadar) {
-    window.loadRadar();
-  }
-}
-
-function showForecast() {
-  console.log("Show forecast clicked");
-  isLiveMode = false;
-  currentTimeOffset = 30;
-
-  // Update UI
-  updateTimelineButtons();
-  updateCurrentTime();
-  updateTimelineHandle();
-
-  // Load forecast radar data (placeholder - would need forecast API)
-  console.log("Loading forecast radar data...");
-}
+function showForecast() {}
 
 // Animate replay from -30 minutes to current time
 function animateReplay() {
@@ -143,52 +92,10 @@ function animateReplay() {
 }
 
 // Update button states
-function updateTimelineButtons() {
-  const buttons = document.querySelectorAll(".timeline-btn");
-  buttons.forEach((btn) => btn.classList.remove("active"));
-
-  const liveBtn = document.getElementById("live-btn");
-  const replayBtn = document.getElementById("replay-btn");
-  const forecastBtn = document.getElementById("forecast-btn");
-
-  if (isLiveMode && liveBtn) {
-    liveBtn.classList.add("active");
-  } else if (currentTimeOffset <= -25 && replayBtn) {
-    replayBtn.classList.add("active");
-  } else if (currentTimeOffset >= 25 && forecastBtn) {
-    forecastBtn.classList.add("active");
-  }
-}
+function updateTimelineButtons() {}
 
 // Handle timeline slider clicks
-function handleTimelineClick(event) {
-  const slider = document.getElementById("timeline-slider");
-  if (!slider) return;
-
-  const rect = slider.getBoundingClientRect();
-  const clickX = event.clientX - rect.left;
-  const percentage = (clickX / rect.width) * 100;
-
-  // Convert percentage to time offset (-30 to +30 minutes)
-  currentTimeOffset = Math.round((percentage / 100) * 60 - 30);
-  currentTimeOffset = Math.max(-30, Math.min(30, currentTimeOffset)); // Clamp to bounds
-
-  // Update mode
-  isLiveMode = currentTimeOffset === 0;
-
-  // Stop any animation
-  if (timelineAnimationId) {
-    cancelAnimationFrame(timelineAnimationId);
-    timelineAnimationId = null;
-  }
-
-  // Update UI
-  updateTimelineButtons();
-  updateCurrentTime();
-  updateTimelineHandle();
-
-  console.log(`Timeline clicked: ${currentTimeOffset} minutes offset`);
-}
+function handleTimelineClick(event) {}
 
 // Dragging functionality for timeline handle
 let isDragging = false;
@@ -255,9 +162,7 @@ function initializeTimeline() {
 
   // Update time display every second
   setInterval(() => {
-    if (isLiveMode) {
-      updateCurrentTime();
-    }
+    updateCurrentTime();
   }, 1000);
 }
 

--- a/index.html
+++ b/index.html
@@ -58,51 +58,23 @@
 
     <!-- Enhanced Radar Legend -->
     <div class="radar-legend">
-      <h4>Precipitation Intensity</h4>
-      <div class="legend-scale">
-        <div class="legend-item">
-          <div class="legend-color-info">
-            <div class="legend-color legend-clear"></div>
-            <span>Clear</span>
-          </div>
-          <span class="legend-value">0 mm/h</span>
-        </div>
-        <div class="legend-item">
-          <div class="legend-color-info">
-            <div class="legend-color legend-light"></div>
-            <span>Light</span>
-          </div>
-          <span class="legend-value">0.1-2.5</span>
-        </div>
-        <div class="legend-item">
-          <div class="legend-color-info">
-            <div class="legend-color legend-moderate"></div>
-            <span>Moderate</span>
-          </div>
-          <span class="legend-value">2.5-10</span>
-        </div>
-        <div class="legend-item">
-          <div class="legend-color-info">
-            <div class="legend-color legend-heavy"></div>
-            <span>Heavy</span>
-          </div>
-          <span class="legend-value">10-50</span>
-        </div>
-        <div class="legend-item">
-          <div class="legend-color-info">
-            <div class="legend-color legend-intense"></div>
-            <span>Intense</span>
-          </div>
-          <span class="legend-value">50-100</span>
-        </div>
-        <div class="legend-item">
-          <div class="legend-color-info">
-            <div class="legend-color legend-extreme"></div>
-            <span>Extreme</span>
-          </div>
-          <span class="legend-value">100+ mm/h</span>
+      <h4 id="legend-title">Precipitation (Reflectivity dBZ)</h4>
+      <div class="legend-vertical">
+        <div class="legend-gradient-bar vertical"></div>
+        <div class="legend-ticklist">
+          <div class="legend-tick"><span class="tick-label">Extreme Storms</span><span class="tick-value">55+ dBZ</span></div>
+          <div class="legend-tick"><span class="tick-label">Intense Storm</span><span class="tick-value">45–55 dBZ</span></div>
+          <div class="legend-tick"><span class="tick-label">Heavy Rain</span><span class="tick-value">35–45 dBZ</span></div>
+          <div class="legend-tick"><span class="tick-label">Moderate Rain</span><span class="tick-value">20–35 dBZ</span></div>
+          <div class="legend-tick"><span class="tick-label">Light Rain</span><span class="tick-value">5–20 dBZ</span></div>
+          <div class="legend-tick"><span class="tick-label">Very Light / Drizzle</span><span class="tick-value">0–5 dBZ</span></div>
         </div>
       </div>
+      <div class="ptype-row">
+        <span class="ptype-label">Precipitation Type</span>
+        <span id="ptype-badge" class="ptype-badge ptype-none">—</span>
+      </div>
+
     </div>
 
     <!-- Timeline Controls -->
@@ -114,22 +86,11 @@
         </div>
       </div>
 
-      <div class="timeline-controls">
-        <button class="timeline-btn" id="replay-btn" onclick="replayRadar()">
-          <span>⪪</span> Replay
-        </button>
-        <button class="timeline-btn active" id="live-btn" onclick="goLive()">
-          <span>🔴</span> Live
-        </button>
-        <button class="timeline-btn" id="forecast-btn" onclick="showForecast()">
-          <span>⩥</span> +1hr
-        </button>
-      </div>
+      
 
       <div
         class="timeline-slider"
         id="timeline-slider"
-        onclick="handleTimelineClick(event)"
       >
         <div class="timeline-track">
           <div


### PR DESCRIPTION
… format (#1)

* feat(legend): switch to dBZ bins and standard radar colors; add tile layer classNames; local config.js (gitignored)

* style(legend): Apple-like color palette and subtle tile filters for Apple look

* style(apple): dark basemap, 512px RainViewer tiles, screen blend, blue→purple legend

* style(apple): switch to light basemap, brighten legend, adjust blending for light theme

* style(apple): darker legend card, tuned clouds, added OWM precip overlays for smoother appearance

* feat(legend): add overlay types (Clouds, Rain, Snow) with swatches; add OWM snow and tuned blends

* fix(legend): align colors to RainViewer reflectivity; remove ambiguous OWM precip/snow from default; keep Clouds; add overlay controls base

* feat(overlays): add toggle controls for radar/clouds/rain/snow and show/hide legend items accordingly

* revert(ui): remove overlay toggles per request; style(map): switch basemap to CARTO Voyager for bluer water

* legend: add gradient bar; radar: use RainViewer classic scheme; align legend swatches

* legend(ui): remove color blocks; add vertical gradient with aligned labels and dBZ values

* legend: use human-friendly labels with dBZ (Light/Moderate/Heavy Rain, Storms)

* legend: extend vertical gradient with blue tones; labels include drizzle; radar: Universal Blue scheme

* legend: add precipitation type badge; map: keep Universal Blue; labels human-friendly

* legend: remove Overlay Types; right-align dBZ values; keep vertical gradient

* timeline: remove buttons and interactions; keep rolling 24h time; clean styles